### PR TITLE
Use SASS's asset-url helper instead of font-url

### DIFF
--- a/app/assets/stylesheets/entypo-fonts.css.scss
+++ b/app/assets/stylesheets/entypo-fonts.css.scss
@@ -1,9 +1,9 @@
 @font-face {
   font-family: 'entypo';
-  src: url(asset-path('entypo.eot'));
-  src: url(asset-path('entypo.eot?#iefix')) format('embedded-opentype'),
-       url(asset-path('entypo.woff')) format('woff'),
-       url(asset-path('entypo.ttf')) format('truetype'),
-       url(asset-path('entypo.svg#entypo')) format('svg');
+  src: asset-url('entypo.eot');
+  src: asset-url('entypo.eot?#iefix') format('embedded-opentype'),
+       asset-url('entypo.woff') format('woff'),
+       asset-url('entypo.ttf') format('truetype'),
+       asset-url('entypo.svg#entypo') format('svg');
   font-weight: normal; font-style: normal;
 }


### PR DESCRIPTION
font-url will only generate paths to the "assets/" directory, however it will not include any cache-busting timestamps from the asset pipeline.

SASS has the asset-url helper to do just this.

See:
http://stackoverflow.com/questions/8334573/asset-path-in-scss-file-rails#answer-8663533
http://rubydoc.info/github/petebrowne/sprockets-sass/master/Sprockets/Sass/Functions#asset_url-instance_method
