### PR TITLE
Adding webkit webkit-font-smoothing

### DIFF
--- a/app/assets/stylesheets/entypo.css.scss
+++ b/app/assets/stylesheets/entypo.css.scss
@@ -9,6 +9,7 @@
   width: 1.1em;
   margin-right: .1em;
   text-align: center;
+  -webkit-font-smoothing: antialiased;
 }
 
 /* main icon map */


### PR DESCRIPTION
Hey, in Safari it displays much nicer with `-webkit-font-smoothing`. I took screenshots to compare:

![screenshot 2013-11-14 14 32 47](https://f.cloud.github.com/assets/50943/1541222/70c9d032-4d31-11e3-8390-c2c54ad063f3.png)
![screenshot 2013-11-14 14 32 53](https://f.cloud.github.com/assets/50943/1541221/700f3a6a-4d31-11e3-966f-f2739653f8de.png)
